### PR TITLE
fix: Removed error message `withComponentDefaults requires namespace`

### DIFF
--- a/packages/gatsby-theme-wordpress-basic/src/components/Article.js
+++ b/packages/gatsby-theme-wordpress-basic/src/components/Article.js
@@ -22,7 +22,7 @@ Article.propTypes = {
   styles: PropTypes.objectOf(PropTypes.string),
 };
 
-export default withComponentDefaults(Article, 'article');
+export default withComponentDefaults(Article, "article");
 
 function Article({
   className,

--- a/packages/gatsby-theme-wordpress-basic/src/components/Article.js
+++ b/packages/gatsby-theme-wordpress-basic/src/components/Article.js
@@ -22,7 +22,7 @@ Article.propTypes = {
   styles: PropTypes.objectOf(PropTypes.string),
 };
 
-export default withComponentDefaults(Article);
+export default withComponentDefaults(Article, 'article');
 
 function Article({
   className,


### PR DESCRIPTION
On every page load an error message that says withComponentDefaults requires namespace`
shows up. Looks like the Article component missed including a namespace
when calling the withComponentDefaults-function.