### PR TITLE
feat: set maxWidth on WPCaption comps when using attachment sizes in WP

### DIFF
--- a/packages/gatsby-theme-wordpress-basic/src/utils/html.js
+++ b/packages/gatsby-theme-wordpress-basic/src/utils/html.js
@@ -78,9 +78,15 @@ export default function createHTMLProcessor({ rehypeParse: parse }) {
 
     WPCaption.propTypes = {
       attachment: PropTypes.string,
+      width: PropTypes.number,
       children: PropTypes.node,
     };
-    function WPCaption({ attachment: attachmentId, children, ...restProps }) {
+    function WPCaption({
+      attachment: attachmentId,
+      width: imgWidth,
+      children,
+      ...restProps
+    }) {
       let attachment = contentMedia.find(
         (attachment) => attachment.databaseId === Number(attachmentId),
       );
@@ -107,6 +113,7 @@ export default function createHTMLProcessor({ rehypeParse: parse }) {
           base64={base64}
           aspectRatio={aspectRatio}
           alt={alt}
+          maxWidth={imgWidth}
           caption={
             React.Children.count(children) === 0
               ? processContent(caption)
@@ -148,8 +155,10 @@ export default function createHTMLProcessor({ rehypeParse: parse }) {
         visit(tree, isElementWithClassName("wp-caption"), (node, index) => {
           node.tagName = "wp-caption";
           let [, attachment] = node.properties.id.match(/(\d+)/);
+          let [width] = node.properties.style.match(/\d+/g);
           node.properties = {
             attachment,
+            width: parseInt(width),
           };
           let newChildren = [];
           visit(node, isElementWithClassName("wp-caption-text"), (node) => {


### PR DESCRIPTION
Using pre-defined thumbnail sizes in the rich text editor only works for images without captions. This adds support for WPCaption components as well. 

<img width="581" alt="Skärmavbild 2022-05-04 kl  15 56 09" src="https://user-images.githubusercontent.com/4332944/166696587-f0a71b27-7885-40f4-915b-4911e262038c.png">

WP adds 10px in padding to captioned images by default, so it should preferably be paired with a WP filter as well:

```
add_filter('img_caption_shortcode_width', function($width) {
  return $width - 10;
});
```