### PR TITLE
feat: Merge stringifierComponents in HtmlProcessorExtensionProvider

### DIFF
--- a/packages/gatsby-theme-wordpress-basic/src/components/HtmlProcessorExtensionProvider.js
+++ b/packages/gatsby-theme-wordpress-basic/src/components/HtmlProcessorExtensionProvider.js
@@ -2,7 +2,7 @@ import { mergeWith } from "lodash/fp";
 import React, { useContext } from "react";
 
 const mergeAndConcat = mergeWith((a, b) =>
-  Array.isArray(a) ? a.concat(b) : b,
+  Array.isArray(a) ? a.concat(b) : typeof a === "object" && a !== null ? {...a, ...b} : b,
 );
 
 import htmlProcessorExtensionContext from "../contexts/htmlProcessorExtensionContext";

--- a/packages/gatsby-theme-wordpress-basic/src/components/HtmlProcessorExtensionProvider.js
+++ b/packages/gatsby-theme-wordpress-basic/src/components/HtmlProcessorExtensionProvider.js
@@ -2,7 +2,11 @@ import { mergeWith } from "lodash/fp";
 import React, { useContext } from "react";
 
 const mergeAndConcat = mergeWith((a, b) =>
-  Array.isArray(a) ? a.concat(b) : typeof a === "object" && a !== null ? {...a, ...b} : b,
+  Array.isArray(a)
+    ? a.concat(b)
+    : typeof a === "object" && a !== null
+    ? { ...a, ...b }
+    : b,
 );
 
 import htmlProcessorExtensionContext from "../contexts/htmlProcessorExtensionContext";

--- a/packages/gatsby-theme-wordpress-basic/src/components/HtmlProcessorExtensionProvider.js
+++ b/packages/gatsby-theme-wordpress-basic/src/components/HtmlProcessorExtensionProvider.js
@@ -1,13 +1,11 @@
 import { mergeWith } from "lodash/fp";
 import React, { useContext } from "react";
 
-const mergeAndConcat = mergeWith((a, b) =>
-  Array.isArray(a)
-    ? a.concat(b)
-    : typeof a === "object" && a !== null
-    ? { ...a, ...b }
-    : b,
-);
+const mergeAndConcat = mergeWith((a, b) => {
+  if (Array.isArray(a)) {
+    return a.concat(b);
+  }
+});
 
 import htmlProcessorExtensionContext from "../contexts/htmlProcessorExtensionContext";
 


### PR DESCRIPTION
Since `stringifierComponents` is an object we just used the `stringifierComponents` from the last extension, making it impossible to add them in the `gatsby-browser` in a project.

Changed so we merge the objects instead, taking the property from the later extension if there is a key conflict.